### PR TITLE
[BUGFIX] Write temporary font.css asset to the correct TYPO3 directory

### DIFF
--- a/Classes/Provider/CssIconProvider.php
+++ b/Classes/Provider/CssIconProvider.php
@@ -66,7 +66,7 @@ class CssIconProvider extends AbstractIconProvider
 
     public function getTempPath(): string
     {
-        return Environment::getPublicPath() . '/typo3temp/tx_bwicons/' . $this->getCacheIdentifier() . '/' . $this->getId();
+        return Environment::getPublicPath() . '/typo3temp/assets/tx_bwicons/' . $this->getCacheIdentifier() . '/' . $this->getId();
     }
 
     protected function extractFontFilesFromFontFaces(string $fileExtension, array $fontFaces): array


### PR DESCRIPTION
Resolves: #4