### PR TITLE
Fix css paths in backend include

### DIFF
--- a/Classes/Form/Element/IconSelection.php
+++ b/Classes/Form/Element/IconSelection.php
@@ -4,6 +4,7 @@ namespace Blueways\BwIcons\Form\Element;
 
 use Blueways\BwIcons\Utility\HelperUtility;
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
@@ -24,7 +25,10 @@ class IconSelection extends AbstractFormElement
 
         $helperUtil = GeneralUtility::makeInstance(HelperUtility::class, $pid, $iconProviders);
         $styleSheets = $helperUtil->getStyleSheets();
-        $resultArray['stylesheetFiles'] = $styleSheets;
+        $styleSheetPaths = array_map(static function ($styleSheet) {
+            return Environment::getPublicPath() . $styleSheet;
+        }, $styleSheets);
+        $resultArray['stylesheetFiles'] = $styleSheetPaths;
 
         $resultArray['requireJsModules'][] = ['TYPO3/CMS/BwIcons/IconSelection' => 'function(IconSelection){top.require([], function() { const iconPicker = new IconSelection(' . $pid . ',\'' . rawurlencode($iconProviders) . '\'); iconPicker.initForFormElement("' . $parameterArray['itemFormElName'] . '"); }); }'];
 

--- a/Classes/Provider/CssIconProvider.php
+++ b/Classes/Provider/CssIconProvider.php
@@ -131,7 +131,7 @@ class CssIconProvider extends AbstractIconProvider
             $weight = is_a($weight, Size::class) ? $weight->getSize() : $weight;
             $styleRules = $ruleSet->getRules('font-style');
             return [
-                'font-family' => $familyRules[0]->getValue()->getString(),
+                'font-family' => is_string($familyRules[0]->getValue()) ? $familyRules[0]->getValue() : $familyRules[0]->getValue()->getString(),
                 'weight' => $weight,
                 'style' => count($styleRules) ? $styleRules[0]->getValue() : '',
             ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: Classes/Provider/CssIconProvider.php
 
 		-
+			message: "#^Call to function is_string\\(\\) with Sabberworm\\\\CSS\\\\Value\\\\RuleValueList\\|null will always evaluate to false\\.$#"
+			count: 1
+			path: Classes/Provider/CssIconProvider.php
+
+		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: Classes/Provider/CssIconProvider.php


### PR DESCRIPTION
CSS files were included with relative path which could lead to errors in case of openbase_dir restriction.

solves #21 