### PR TITLE
fix: stop copying not needed of font files

### DIFF
--- a/Classes/Utility/SvgReaderUtility.php
+++ b/Classes/Utility/SvgReaderUtility.php
@@ -6,14 +6,7 @@ class SvgReaderUtility
 {
     public function getGlyphs($svgFile): array
     {
-        $svgCopy = 'font.svg';
-
-        if (file_exists($svgCopy)) {
-            unlink($svgCopy);
-        }
-        copy($svgFile, $svgCopy);
-
-        $svgContent = file_get_contents($svgCopy);
+        $svgContent = file_get_contents($svgFile);
 
         $xmlInit = simplexml_load_string($svgContent);
         $svgJson = json_encode($xmlInit);

--- a/Classes/Utility/TtfReaderUtility.php
+++ b/Classes/Utility/TtfReaderUtility.php
@@ -16,15 +16,8 @@ class TtfReaderUtility
 
     public function getGlyphs($ttfFile): array
     {
-        $ttfCopy = 'font.ttf';
-
-        if (file_exists($ttfCopy)) {
-            unlink($ttfCopy);
-        }
-        copy($ttfFile, $ttfCopy);
-
         try {
-            $font = Font::load($ttfCopy);
+            $font = Font::load($ttfFile);
             $font->parse();
             $chars = $font->getUnicodeCharMap();
             $cleanChars = array_map(function ($char) {


### PR DESCRIPTION
In `TtfReaderUtility`and `SvgReaderUtility` font files were copied to prevent unintended manipulation of these files. Since these operations are read-only, the copy process is not needed anymore.