### PR TITLE
feat: add accessible images

### DIFF
--- a/Classes/ViewHelpers/IconViewHelper.php
+++ b/Classes/ViewHelpers/IconViewHelper.php
@@ -36,6 +36,8 @@ class IconViewHelper extends AbstractViewHelper
             $attributes['data-icon-base-name'] = $baseName;
             $attributes['src'] = $webPath;
             $attributes['loading'] = 'lazy';
+            $attributes['alt'] = '';
+            $attributes['role'] = 'presentation';
 
             $attrString = static::concatAttributes($attributes);
             return '<img ' . $attrString . ' />';


### PR DESCRIPTION
If icons are rendered as images, those images have to be accessible. In this case we have to add a „null“ alt attribute and set the role of the image to „presentation“.

More information regarding accessible and decorative images can be found here:

- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role
- https://www.w3.org/WAI/tutorials/images/decorative/

Closes: https://github.com/maikschneider/bw_icons/issues/26 