### PR TITLE
Configure icon markup

### DIFF
--- a/Classes/Provider/AbstractIconProvider.php
+++ b/Classes/Provider/AbstractIconProvider.php
@@ -17,6 +17,11 @@ abstract class AbstractIconProvider
         $this->options = $options;
     }
 
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
     public function getTitle(): string
     {
         return $this->title;

--- a/Classes/Utility/HelperUtility.php
+++ b/Classes/Utility/HelperUtility.php
@@ -41,6 +41,7 @@ class HelperUtility
                 $tab['id'] = $provider->getId();
                 $tab['title'] = $provider->getTitle();
                 $tab['folders'] = $provider->getIcons();
+                $tab['markup'] = $provider->getOptions()['markup'] ?? '';
 
                 $tabs[] = $tab;
             }

--- a/Classes/ViewHelpers/IconViewHelper.php
+++ b/Classes/ViewHelpers/IconViewHelper.php
@@ -44,7 +44,7 @@ class IconViewHelper extends AbstractViewHelper
             return '<img ' . $attrString . ' />';
         }
 
-        $markup = $arguments['markup'];
+        $markup = $arguments['markup'] ?: '<i class="###ICON###"></i>';
         $markup = str_replace('###ICON###', $arguments['icon'], $markup);
 
         $doc = new DOMDocument();
@@ -71,9 +71,9 @@ class IconViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'markup',
             'string',
-            'Markup of the',
+            'Markup of the icon. Use ###ICON### as placeholder for the icon name.',
             false,
-            '<i class="###ICON###"></i>'
+            ''
         );
         $this->registerArgument(
             'additionalAttributes',

--- a/Classes/ViewHelpers/IconViewHelper.php
+++ b/Classes/ViewHelpers/IconViewHelper.php
@@ -2,6 +2,7 @@
 
 namespace Blueways\BwIcons\ViewHelpers;
 
+use DOMDocument;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -43,9 +44,17 @@ class IconViewHelper extends AbstractViewHelper
             return '<img ' . $attrString . ' />';
         }
 
-        $attributes['class'] = $arguments['icon'];
-        $attrString = static::concatAttributes($attributes);
-        return '<i ' . $attrString . '></i>';
+        $markup = $arguments['markup'];
+        $markup = str_replace('###ICON###', $arguments['icon'], $markup);
+
+        $doc = new DOMDocument();
+        $doc->loadHTML($markup, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $element = $doc->getElementsByTagName('*')->item(0);
+        foreach ($attributes as $attributeName => $attributeValue) {
+            $element->setAttribute($attributeName, $attributeValue);
+        }
+
+        return $doc->saveHTML() ?: '';
     }
 
     protected static function concatAttributes(array $attributes): string
@@ -59,7 +68,13 @@ class IconViewHelper extends AbstractViewHelper
     {
         parent::initializeArguments();
         $this->registerArgument('icon', 'string', 'The icon name', true);
-        $this->registerArgument('provider', 'string', 'PageTS did of the used IconProvider', false);
+        $this->registerArgument(
+            'markup',
+            'string',
+            'Markup of the',
+            false,
+            '<i class="###ICON###"></i>'
+        );
         $this->registerArgument(
             'additionalAttributes',
             'array',

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ mod.tx_bwicons {
     icomoon {
         title = Icomoon
         file = https://i.icomoon.io/public/b23ec64zea/Project/style.css
+        # optional: adjust markup in backend wizard
+        # defaults to <i class="###ICON###"></i>
+        markup = <span class="my-custom-class ###ICON###"></span>
     }
 }
 ```

--- a/Resources/Private/Template/Modal.html
+++ b/Resources/Private/Template/Modal.html
@@ -75,7 +75,7 @@
                                     <f:variable name="cssClassName">thumbnail--white</f:variable>
                                 </f:if>
 								<a href="#" class="thumbnail {cssClassName}">
-									<bw:icon icon="{icon}"/>
+									<bw:icon icon="{icon}" markup="{tab.markup}" />
 								</a>
 							</div>
 						</f:for>

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     }
   },
   "config": {
+    "sort-packages": true,
     "vendor-dir": "vendor",
     "allow-plugins": {
       "typo3/cms-composer-installers": true,
@@ -30,9 +31,14 @@
     }
   ],
   "license": [
-    "GPL-3.0-or-later"
+    "GPL-2.0-or-later"
   ],
   "require-dev": {
+    "bk2k/bootstrap-package": "dev-master",
+    "clue/phar-composer": "^1.0",
+    "friendsofphp/php-cs-fixer": "^3.12",
+    "phpmd/phpmd": "^2.13.0",
+    "saschaegerer/phpstan-typo3": "^1.8",
     "typo3/cms-backend": "^12.0",
     "typo3/cms-belog": "^12.0",
     "typo3/cms-beuser": "^12.0",
@@ -59,11 +65,6 @@
     "typo3/cms-seo": "^12.0",
     "typo3/cms-setup": "^12.0",
     "typo3/cms-tstemplate": "^12.0",
-    "bk2k/bootstrap-package": "dev-master",
-    "clue/phar-composer": "^1.0",
-    "friendsofphp/php-cs-fixer": "^3.12",
-    "saschaegerer/phpstan-typo3": "^1.8",
-    "phpmd/phpmd": "^2.13.0",
     "typo3/testing-framework": "^8.0"
   },
   "autoload": {
@@ -89,12 +90,12 @@
   },
   "require": {
     "php": "^8.0",
-    "sabberworm/php-css-parser": "8.4.0",
-    "ext-simplexml": "*",
-    "ext-json": "*",
-    "typo3/cms-core": "^12.0",
-    "phenx/php-font-lib": "0.5.4",
     "ext-dom": "*",
-    "ext-libxml": "*"
+    "ext-json": "*",
+    "ext-libxml": "*",
+    "ext-simplexml": "*",
+    "phenx/php-font-lib": "0.5.4",
+    "sabberworm/php-css-parser": "8.4.0",
+    "typo3/cms-core": "^12.4"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,8 @@
     "ext-simplexml": "*",
     "ext-json": "*",
     "typo3/cms-core": "^12.0",
-    "phenx/php-font-lib": "0.5.4"
+    "phenx/php-font-lib": "0.5.4",
+    "ext-dom": "*",
+    "ext-libxml": "*"
   }
 }


### PR DESCRIPTION
This PR adds a new argument `markup` to the `bw:icon` ViewHelper. This ViewHelper is used in backend wizard to render the icon gallery. The `markup` option can be added to the IconProvider.

```
icomoon {
    title = Icomoon
    file = https://i.icomoon.io/public/b23ec64zea/Project/style.css
    # optional: adjust markup in backend wizard
    markup = <span class="my-custom-class ###ICON###"></span>
}
```

solves #48 