### PR TITLE
Remove duplicate label in v12

### DIFF
--- a/Classes/Form/Element/IconSelection.php
+++ b/Classes/Form/Element/IconSelection.php
@@ -37,7 +37,7 @@ class IconSelection extends AbstractFormElement
 
         $currentIcon = $itemFormElValue ? new WizardIcon($itemFormElValue) : null;
 
-        $html = $this->renderLabel($fieldId);
+        $html = $wizardConfig->typo3Version > 12 ? $this->renderLabel($fieldId) : '';
         $html .= '<div class="formengine-field-item t3js-formengine-field-item">';
         $html .= '<div class="form-wizards-wrap">';
         $html .= '<div class="form-wizards-element">';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved label display for icon selection fields to ensure compatibility with different TYPO3 versions. Labels are now shown only for supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->