### PR TITLE
fix: Fixes fallback data type of weight

### DIFF
--- a/Classes/Provider/CssIconProvider.php
+++ b/Classes/Provider/CssIconProvider.php
@@ -302,7 +302,7 @@ class CssIconProvider extends AbstractIconProvider
             $familyRuleName = $familyRules[0]->getValue()->getString();
 
             $weightRules = $ruleSet->getRules('font-weight');
-            $weight = count($weightRules) ? $weightRules[0]->getValue() : '';
+            $weight = count($weightRules) ? $weightRules[0]->getValue() : 0;
             $weight = is_a($weight, Size::class) ? $weight->getSize() : $weight;
 
             $styleRules = $ruleSet->getRules('font-style');


### PR DESCRIPTION
Setting weight to an empty String leads to a ciritical error.

Because later this function gets called (line 203):

`if (self::cssBlockMatchesFontWeight($blockRule, $font['weight'])) {`
and it expects a float data type:
`protected static function cssBlockMatchesFontWeight(RuleSet $ruleSet, float $fontWeight): bool`

## PoC
the error occurs when using a CSS font-face without a `font-weight` attribute:
myfont.css:
```css
@charset "UTF-8";
@font-face {
 	font-family: 'myfont';
	src: url("../Fonts/vendor/[...].woff2?") format("woff2"), url("../Fonts/vendor/[...].woff") format("woff"), url("../Fonts/vendor/[...].eot") format("embedded-opentype"), url("../Fonts/vendor/[...].ttf") format("truetype"), url("../Fonts/vendor/[...].svg") format("svg");
}
```
include that file to your config and the parsing will fail:
```ts
mod.tx_bwicons {
	myfont = Blueways\BwIcons\Provider\CssIconProvider
	myfont {
		title = MyFont
		file = EXT:my_ext/Resources/Public/Stylesheets/myfont.css
	}
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of font weight default values for enhanced consistency in CSS icon rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->